### PR TITLE
set channel validating webhook owner as channel CRD

### DIFF
--- a/pkg/webhook/wireupwebhook.go
+++ b/pkg/webhook/wireupwebhook.go
@@ -264,6 +264,7 @@ func setWebhookOwnerReferences(c client.Client, logger logr.Logger, obj metav1.O
 	channelCrdName := "channels.apps.open-cluster-management.io"
 	key := types.NamespacedName{Name: channelCrdName}
 	owner := &apixv1.CustomResourceDefinition{}
+
 	if err := c.Get(context.TODO(), key, owner); err != nil {
 		logger.Error(err, fmt.Sprintf("Failed to set webhook owner references for %s", obj.GetName()))
 		return
@@ -277,7 +278,6 @@ func setWebhookOwnerReferences(c client.Client, logger logr.Logger, obj metav1.O
 			UID:        owner.UID,
 		},
 	})
-
 }
 
 func newWebhookServiceTemplate(svcKey types.NamespacedName, webHookPort, webHookServicePort int, deploymentSelector map[string]string) *corev1.Service {


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/open-cluster-management/backlog/issues/17319

Set channel validating webhook owner as channel CRD. Thus the webhook will be removed when the channel CRD is removed by ACM uninstaller.