### PR TITLE
Update actions and ubtunu runner version

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -19,7 +19,7 @@ defaults:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   main:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       REGISTRY: localhost:5000
       RUN_ON: github
@@ -30,9 +30,9 @@ jobs:
     steps:
     # Checks out a copy of your repository on the ubuntu-latest machine
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up go version
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '^1.19' # The Go version to download (if necessary) and use.
     - run: go version


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

Updating GitHub actions per https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

And ubuntu runner as per ubtunu-18.04 deprecation https://github.com/actions/runner-images/issues/6002