### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for multicluster-operators-channel-acm-214

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -17,7 +17,8 @@ ENV OPERATOR=/usr/local/bin/multicluster-operators-channel \
     USER_NAME=multicluster-operators-channel
 
 LABEL \
-    name="multicloud-operators-channel" \
+    name="rhacm2/multicluster-operators-channel-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     com.redhat.component="multicloud-operators-channel" \
     description="multicluster channel controller" \
     maintainer="acm-contact@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
