### PR TITLE
ACM-30168 Add cluster TLS profile for webhook server

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -23,7 +24,9 @@ import (
 	"os"
 	"path/filepath"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 
 	v1 "k8s.io/api/core/v1"
@@ -51,6 +54,7 @@ import (
 	"open-cluster-management.io/multicloud-operators-channel/pkg/apis"
 	"open-cluster-management.io/multicloud-operators-channel/pkg/controller"
 	"open-cluster-management.io/multicloud-operators-channel/pkg/utils"
+	"open-cluster-management.io/multicloud-operators-channel/pkg/utils/tlsconfig"
 	chWebhook "open-cluster-management.io/multicloud-operators-channel/pkg/webhook"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -122,6 +126,11 @@ func RunManager() {
 		logger.Info("connect to external api server, kubeconfig:" + options.KubeConfig)
 	}
 
+	// Cache cluster TLS profile (API Server) for use by webhook listener.
+	schemeForTLS := runtime.NewScheme()
+	_ = configv1.AddToScheme(schemeForTLS)
+	tlsconfig.InitClusterTLSConfig(context.Background(), cfg, schemeForTLS)
+
 	enableLeaderElection := false
 
 	if _, err := rest.InClusterConfig(); err == nil {
@@ -139,7 +148,9 @@ func RunManager() {
 
 	webhookOption := k8swebhook.Options{}
 	webhookOption.TLSOpts = append(webhookOption.TLSOpts, func(config *tls.Config) {
-		config.MinVersion = chv1.TLSMinVersionInt
+		c := tlsconfig.GetClusterTLSConfig()
+		config.MinVersion = c.MinVersion
+		config.CipherSuites = c.CipherSuites
 	})
 	webhookServer := k8swebhook.NewServer(webhookOption)
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.36.1
+	github.com/openshift/api v0.0.0-20251009160459-595e66a09a84
+	github.com/openshift/library-go v0.0.0-20251009131428-6c2d3d0d6f05
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -130,6 +132,7 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiserver v0.34.1 // indirect
 	k8s.io/cli-runtime v0.33.3 // indirect
 	k8s.io/component-base v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,7 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5 h1:l2zaLDubNhW4XO3LnliVj0GXO3+/CGNJAg1dcN2Fpfw=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5/go.mod h1:ny6zBSQZi2JxIeYcv7kt2sH2PXJtirBN7RDhRpxPkxU=
 github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
@@ -252,6 +253,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/openshift/api v0.0.0-20251009160459-595e66a09a84 h1:8LC9yrt+LhRgZ1eVaHb2uxyUET/fqpyelSk2hke7wd4=
+github.com/openshift/api v0.0.0-20251009160459-595e66a09a84/go.mod h1:SPLf21TYPipzCO67BURkCfK6dcIIxx0oNRVWaOyRcXM=
+github.com/openshift/library-go v0.0.0-20251009131428-6c2d3d0d6f05 h1:HcgLFEBwErDgOwOJSuV12jPxOcp8Pq1Vs2ilrFBnlXw=
+github.com/openshift/library-go v0.0.0-20251009131428-6c2d3d0d6f05/go.mod h1:vdZXp0uUboiXa/1IlRvVEGTr+e5iA6wCWoXLopgkeKk=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
@@ -463,6 +468,8 @@ k8s.io/apiextensions-apiserver v0.34.1 h1:NNPBva8FNAPt1iSVwIE0FsdrVriRXMsaWFMqJb
 k8s.io/apiextensions-apiserver v0.34.1/go.mod h1:hP9Rld3zF5Ay2Of3BeEpLAToP+l4s5UlxiHfqRaRcMc=
 k8s.io/apimachinery v0.34.1 h1:dTlxFls/eikpJxmAC7MVE8oOeP1zryV7iRyIjB0gky4=
 k8s.io/apimachinery v0.34.1/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
+k8s.io/apiserver v0.34.1 h1:U3JBGdgANK3dfFcyknWde1G6X1F4bg7PXuvlqt8lITA=
+k8s.io/apiserver v0.34.1/go.mod h1:eOOc9nrVqlBI1AFCvVzsob0OxtPZUCPiUJL45JOTBG0=
 k8s.io/cli-runtime v0.33.3 h1:Dgy4vPjNIu8LMJBSvs8W0LcdV0PX/8aGG1DA1W8lklA=
 k8s.io/cli-runtime v0.33.3/go.mod h1:yklhLklD4vLS8HNGgC9wGiuHWze4g7x6XQZ+8edsKEo=
 k8s.io/client-go v0.34.1 h1:ZUPJKgXsnKwVwmKKdPfw4tB58+7/Ik3CrjOEhsiZ7mY=

--- a/pkg/utils/tlsconfig/tlsconfig.go
+++ b/pkg/utils/tlsconfig/tlsconfig.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tlsconfig builds TLS configuration from the OpenShift cluster's API Server.
+//
+// Usage:
+//  1. At process startup (in main), call InitClusterTLSConfig(ctx, restConfig, scheme).
+//     The scheme must have configv1.AddToScheme(scheme) called first.
+//  2. Wherever you need a *tls.Config (servers or clients), call GetClusterTLSConfig().
+//
+// If the cluster is not OpenShift or the APIServer resource is missing, the default
+// (Intermediate profile: TLS 1.2 min, safe ciphers) is used.
+package tlsconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"sync"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cachedTLSConfig *tls.Config
+	initOnce        sync.Once
+)
+
+const apiserverClusterName = "cluster"
+
+// InitClusterTLSConfig loads the cluster's TLS profile once and caches it.
+// Call this at startup (e.g. in each cmd's RunManager) after you have rest.Config.
+// Later calls do nothing. Scheme must include OpenShift config types (configv1.AddToScheme).
+func InitClusterTLSConfig(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme) {
+	initOnce.Do(func() {
+		if cfg != nil && scheme != nil {
+			cachedTLSConfig = fetchTLSConfigFromCluster(ctx, cfg, scheme)
+		}
+
+		if cachedTLSConfig == nil {
+			cachedTLSConfig = profileSpecToTLSConfig(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+		}
+	})
+}
+
+// GetClusterTLSConfig returns the cached TLS config for the process.
+// Use this for http.Server.TLSConfig, http.Transport.TLSClientConfig, webhook TLSOpts, etc.
+// If InitClusterTLSConfig was never called, returns the default (Intermediate) profile.
+func GetClusterTLSConfig() *tls.Config {
+	if cachedTLSConfig != nil {
+		return cachedTLSConfig
+	}
+
+	return profileSpecToTLSConfig(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+}
+
+// fetchTLSConfigFromCluster reads the APIServer "cluster" resource and converts its
+// tlsSecurityProfile into a *tls.Config. Returns nil on any error (e.g. not OpenShift, NotFound).
+func fetchTLSConfigFromCluster(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme) *tls.Config {
+	kubeClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil
+	}
+
+	var apiServer configv1.APIServer
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: apiserverClusterName}, &apiServer); err != nil {
+		return nil
+	}
+
+	spec := getEffectiveProfileSpec(apiServer.Spec.TLSSecurityProfile)
+
+	profileType := configv1.TLSProfileIntermediateType
+	if p := apiServer.Spec.TLSSecurityProfile; p != nil {
+		profileType = p.Type
+	}
+
+	klog.Infof("TLS security profile used: profileType=%s minTLSVersion=%s cipherSuiteCount=%d",
+		profileType, spec.MinTLSVersion, len(spec.Ciphers))
+
+	return profileSpecToTLSConfig(spec)
+}
+
+// getEffectiveProfileSpec turns a TLSSecurityProfile (Old/Intermediate/Modern/Custom)
+// into a concrete TLSProfileSpec (min version + cipher list). Nil or unknown → Intermediate.
+func getEffectiveProfileSpec(profile *configv1.TLSSecurityProfile) *configv1.TLSProfileSpec {
+	if profile == nil {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	if profile.Type == configv1.TLSProfileCustomType && profile.Custom != nil {
+		return &profile.Custom.TLSProfileSpec
+	}
+
+	if spec := configv1.TLSProfiles[profile.Type]; spec != nil {
+		return spec
+	}
+
+	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+}
+
+// profileSpecToTLSConfig converts a TLSProfileSpec (min version + ciphers) into Go's *tls.Config.
+// OpenShift uses OpenSSL-style cipher names; we convert to IANA then to Go constants.
+func profileSpecToTLSConfig(spec *configv1.TLSProfileSpec) *tls.Config {
+	if spec == nil {
+		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+	minVersion := crypto.TLSVersionOrDie(string(spec.MinTLSVersion))
+	ianaCiphers := crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+	cipherIDs := crypto.CipherSuitesOrDie(ianaCiphers)
+	config := &tls.Config{
+		MinVersion:   minVersion,
+		CipherSuites: cipherIDs,
+	}
+
+	return crypto.SecureTLSConfig(config)
+}


### PR DESCRIPTION
Jira ticket: https://redhat.atlassian.net/browse/ACM-30168

Introduce pkg/utils/tlsconfig to read the OpenShift APIServer tlsSecurityProfile and cache a matching crypto/tls.Config. Initialize at manager startup and apply MinVersion and CipherSuites to the admission webhook via GetClusterTLSConfig(). Fall back to the Intermediate TLS profile when APIServer is missing or the cluster is not OpenShift.

* [ ] I have taken backward compatibility into consideration.
