### PR TITLE
[2.17] Bump moby/spdystream to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -142,3 +142,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/moby/spdystream => github.com/moby/spdystream v0.5.1


### PR DESCRIPTION
* [ ] I have taken backward compatibility into consideration.
