### PR TITLE
ACM-39034: Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -25,7 +25,7 @@ jobs:
       RUN_ON: github
     strategy:
       matrix:
-        go: [ '1.25' ]
+        go: [ '1.26' ]
     name: KinD tests
     steps:
     # Checks out a copy of your repository on the ubuntu-latest machine
@@ -34,7 +34,7 @@ jobs:
     - name: Set up go version
       uses: actions/setup-go@v3
       with:
-        go-version: '~1.25' # The Go version to download (if necessary) and use.
+        go-version: '~1.26' # The Go version to download (if necessary) and use.
     - run: go version
 
     - name: Run e2e test on KinD cluster

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/open-cluster-management.io/multicloud-operators-channel
 COPY . .

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-channel
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-channel
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/multicloud-operators-channel
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.16.7


### PR DESCRIPTION
## Summary

Bump Go builder images from 1.25 to 1.26 to address CVE-2026-27145 (crypto/x509 DoS).

## Changes

- `go.mod`: `go 1.25.0` → `go 1.26.0`
- `build/Dockerfile`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.prow`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.rhtap`: brew builder `rhel_9_1.25` → `rhel_9_1.26`
- `.github/workflows/kind.yml`: Go version `1.25` → `1.26`

Made with [Cursor](https://cursor.com)