### PR TITLE
ACM-39014: Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -25,7 +25,7 @@ jobs:
       RUN_ON: github
     strategy:
       matrix:
-        go: [ '1.25' ]
+        go: [ '1.26' ]
     name: KinD tests
     steps:
     # Checks out a copy of your repository on the ubuntu-latest machine

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/open-cluster-management.io/multicloud-operators-channel
 COPY . .

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-channel
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-channel
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/multicloud-operators-channel
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.16.7


### PR DESCRIPTION
## Summary
- Bump Go from 1.25 to **1.26** to remediate **CVE-2026-27145** (GO-2026-5037: inefficient `crypto/x509` hostname verification / DoS).
- Update CI (`kind.yml`) and builder images (`Dockerfile`, `Dockerfile.prow`, `Dockerfile.rhtap`) to the Go 1.26 builders.
- Backport of the approach in https://github.com/stolostron/multicloud-operators-channel/pull/513 for `release-2.15`.

## Changes

- `go.mod`: `go 1.25` → `go 1.26`
- `build/Dockerfile`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.prow`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.rhtap`: brew builder `rhel_9_1.25` → `rhel_9_1.26`
- `.github/workflows/kind.yml`: Go version `1.25` → `1.26`