### PR TITLE
Fix CVEs in channel operator

### DIFF
--- a/pkg/controller/channel/channel_controller.go
+++ b/pkg/controller/channel/channel_controller.go
@@ -51,22 +51,44 @@ import (
 )
 
 var (
-	clusterRules = []rbac.PolicyRule{
+	srtGvk = schema.GroupVersionKind{Group: "", Kind: "Secret", Version: "v1"}
+	cmGvk  = schema.GroupVersionKind{Group: "", Kind: "ConfigMap", Version: "v1"}
+)
+
+// buildChannelRoleRules returns the RBAC rules granted to every managed
+// cluster's application-manager agent for this Channel's namespace.
+// Secret/ConfigMap access is scoped via ResourceNames to the single object
+// the Channel itself references, so a compromised or malicious spoke cannot
+// enumerate or read unrelated Secrets/ConfigMaps in the Channel namespace.
+func buildChannelRoleRules(instance *chv1.Channel) []rbac.PolicyRule {
+	rules := []rbac.PolicyRule{
 		{
 			Verbs:     []string{"get", "list", "watch"},
 			APIGroups: []string{chv1.SchemeGroupVersion.Group},
 			Resources: []string{"channels", "channels/status"},
 		},
-		{
-			Verbs:     []string{"get", "list", "watch"},
-			APIGroups: []string{""},
-			Resources: []string{"secrets", "configmaps"},
-		},
 	}
 
-	srtGvk = schema.GroupVersionKind{Group: "", Kind: "Secret", Version: "v1"}
-	cmGvk  = schema.GroupVersionKind{Group: "", Kind: "ConfigMap", Version: "v1"}
-)
+	if ref := instance.Spec.SecretRef; ref != nil && ref.Name != "" {
+		rules = append(rules, rbac.PolicyRule{
+			Verbs:         []string{"get", "watch"},
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{ref.Name},
+		})
+	}
+
+	if ref := instance.Spec.ConfigMapRef; ref != nil && ref.Name != "" {
+		rules = append(rules, rbac.PolicyRule{
+			Verbs:         []string{"get", "watch"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{ref.Name},
+		})
+	}
+
+	return rules
+}
 
 const (
 	clusterCRDName  = "clusters.clusterregistry.k8s.io"
@@ -460,11 +482,13 @@ func (r *ReconcileChannel) validateClusterRBAC(instance *chv1.Channel, logger lo
 }
 
 func (r *ReconcileChannel) setupRole(instance *chv1.Channel, role *rbac.Role) error {
+	wantRules := buildChannelRoleRules(instance)
+
 	if err := r.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, role); err != nil {
 		if kerr.IsNotFound(err) {
 			role.Name = instance.Name
 			role.Namespace = instance.Namespace
-			role.Rules = clusterRules
+			role.Rules = wantRules
 
 			if err := controllerutil.SetControllerReference(instance, role, r.scheme); err != nil {
 				return gerr.Wrap(err, "failed to set controller reference for role set up")
@@ -480,8 +504,8 @@ func (r *ReconcileChannel) setupRole(instance *chv1.Channel, role *rbac.Role) er
 		return err
 	}
 
-	if !reflect.DeepEqual(role.Rules, clusterRules) {
-		role.Rules = clusterRules
+	if !reflect.DeepEqual(role.Rules, wantRules) {
+		role.Rules = wantRules
 
 		if err := controllerutil.SetControllerReference(instance, role, r.scheme); err != nil {
 			return gerr.Wrap(err, "failed to set controller reference for role set up")

--- a/pkg/controller/channel/channel_controller.go
+++ b/pkg/controller/channel/channel_controller.go
@@ -214,9 +214,10 @@ func (r *ReconcileChannel) handleReferencedObjects(instance *chv1.Channel, req r
 	srtRef := instance.Spec.SecretRef
 
 	if srtRef != nil {
-		if srtRef.Namespace == "" {
-			srtRef.Namespace = instance.GetNamespace()
-		}
+		// Referenced Secrets must live in the Channel's own namespace. Ignore any
+		// caller-supplied srtRef.Namespace so a tenant cannot direct the controller's
+		// privileged client to Get/Update a Secret in a foreign namespace.
+		srtRef.Namespace = instance.GetNamespace()
 
 		if err := r.updatedReferencedObjectLabels(srtRef, srtGvk, log); err != nil {
 			r.Log.Error(err, "failed to update referred secret label")
@@ -234,9 +235,10 @@ func (r *ReconcileChannel) handleReferencedObjects(instance *chv1.Channel, req r
 	//	//sync the channel to the serving-channel annotation in all involved ConfigMaps.
 	cmRef := instance.Spec.ConfigMapRef
 	if cmRef != nil {
-		if cmRef.Namespace == "" {
-			cmRef.Namespace = instance.GetNamespace()
-		}
+		// Referenced ConfigMaps must live in the Channel's own namespace. Ignore any
+		// caller-supplied cmRef.Namespace so a tenant cannot direct the controller's
+		// privileged client to Get/Update a ConfigMap in a foreign namespace.
+		cmRef.Namespace = instance.GetNamespace()
 
 		if err := r.updatedReferencedObjectLabels(cmRef, cmGvk, log); err != nil {
 			r.Log.Error(err, "failed to update referred configMap label")

--- a/pkg/controller/channel/channel_controller_test.go
+++ b/pkg/controller/channel/channel_controller_test.go
@@ -434,3 +434,40 @@ func TestChannelRejectsCrossNamespaceSecretRef(t *testing.T) {
 		types.NamespacedName{Name: "victim-srt", Namespace: "foreign-ns"}, got)).NotTo(gomega.HaveOccurred())
 	g.Expect(got.GetLabels()).NotTo(gomega.HaveKey(chv1.ServingChannel))
 }
+
+// TestBuildChannelRoleRulesScopedToReferencedObjects verifies that the
+// per-Channel Role granted to managed-cluster agents never includes a
+// namespace-wide secrets/configmaps rule; access must be limited to the
+// single referenced object via ResourceNames.
+func TestBuildChannelRoleRulesScopedToReferencedObjects(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	chn := &chv1.Channel{
+		ObjectMeta: metav1.ObjectMeta{Name: "ch", Namespace: targetNamespace},
+		Spec: chv1.ChannelSpec{
+			Type:         targetChannelType,
+			SecretRef:    &corev1.ObjectReference{Name: "ch-srt"},
+			ConfigMapRef: &corev1.ObjectReference{Name: "ch-cm"},
+		},
+	}
+
+	rules := buildChannelRoleRules(chn)
+
+	for _, rule := range rules {
+		for _, res := range rule.Resources {
+			if res == "secrets" || res == "configmaps" {
+				g.Expect(rule.ResourceNames).NotTo(gomega.BeEmpty(),
+					"rule for %s must be scoped via ResourceNames", res)
+				g.Expect(rule.Verbs).NotTo(gomega.ContainElement("list"),
+					"rule for %s must not grant list", res)
+			}
+		}
+	}
+
+	// A Channel with no refs must grant no secret/configmap access at all.
+	bare := &chv1.Channel{ObjectMeta: metav1.ObjectMeta{Name: "bare", Namespace: targetNamespace}}
+	for _, rule := range buildChannelRoleRules(bare) {
+		g.Expect(rule.Resources).NotTo(gomega.ContainElement("secrets"))
+		g.Expect(rule.Resources).NotTo(gomega.ContainElement("configmaps"))
+	}
+}

--- a/pkg/controller/channel/channel_controller_test.go
+++ b/pkg/controller/channel/channel_controller_test.go
@@ -373,3 +373,64 @@ func TestChannelReconcileWithoutClusterCRD(t *testing.T) {
 	_, err = rec.Reconcile(context.TODO(), reconcile.Request{})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 }
+
+// TestChannelRejectsCrossNamespaceSecretRef verifies that a Channel whose
+// spec.secretRef.namespace points at a foreign namespace cannot cause the
+// controller to mutate that foreign Secret. The reconciler must pin the
+// reference to the Channel's own namespace.
+func TestChannelRejectsCrossNamespaceSecretRef(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	foreignNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foreign-ns"}}
+	victimSrt := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-srt", Namespace: "foreign-ns"},
+	}
+
+	chn := &chv1.Channel{
+		ObjectMeta: metav1.ObjectMeta{Name: "xns", Namespace: targetNamespace},
+		Spec: chv1.ChannelSpec{
+			Type:      targetChannelType,
+			Pathname:  targetNamespace,
+			SecretRef: &corev1.ObjectReference{Name: "victim-srt", Namespace: "foreign-ns", Kind: "secret"},
+		},
+	}
+
+	mgr, err := manager.New(cfg, manager.Options{Metrics: metricsserver.Options{BindAddress: "0"}})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c = mgr.GetClient()
+	tRecorder := record.NewBroadcaster().NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "channel"})
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	dynamicClient := dynamic.NewForConfigOrDie(cfg)
+	rec := newReconciler(mgr, dynamicClient, tRecorder, logr.Discard()).(*ReconcileChannel)
+
+	g.Expect(c.Create(context.TODO(), foreignNs)).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), victimSrt)
+	g.Expect(c.Create(context.TODO(), victimSrt)).NotTo(gomega.HaveOccurred())
+
+	defer c.Delete(context.TODO(), chn)
+	g.Expect(c.Create(context.TODO(), chn)).NotTo(gomega.HaveOccurred())
+
+	rq := reconcile.Request{NamespacedName: types.NamespacedName{Name: chn.Name, Namespace: chn.Namespace}}
+
+	// handleReferencedObjects must look up the Secret in the Channel's namespace,
+	// not the attacker-supplied foreign-ns, so it should fail to find it.
+	err = rec.handleReferencedObjects(chn, rq, logr.Discard())
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(chn.Spec.SecretRef.Namespace).To(gomega.Equal(targetNamespace))
+
+	// The foreign Secret must remain untouched: no serving-channel label.
+	got := &corev1.Secret{}
+	g.Expect(c.Get(context.TODO(),
+		types.NamespacedName{Name: "victim-srt", Namespace: "foreign-ns"}, got)).NotTo(gomega.HaveOccurred())
+	g.Expect(got.GetLabels()).NotTo(gomega.HaveKey(chv1.ServingChannel))
+}


### PR DESCRIPTION
- CVE-2026-64927 (f002) — pin SecretRef/ConfigMapRef to Channel namespace
- CVE-2026-73122 (f003) — scope per-Channel Role to referenced Secret/ConfigMap onl