### PR TITLE
Update ubi9-minimal base image to ubi9-minimal-pqc in Dockerfile.rhtap

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -7,7 +7,7 @@ RUN rm -fr vendor && \
         make -f Makefile.prow build
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 RUN microdnf update -y && \
      microdnf clean all


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.
https://redhat.atlassian.net/browse/ACM-41551
